### PR TITLE
Fixed More Codacy Issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ update() {
         return
     fi
 
-    curl -fsSL ${UPDATE_SCRIPT_SOURCE_URL} | sudo \${SHELL}
+    curl -fsSL "${UPDATE_SCRIPT_SOURCE_URL}" | sudo \${SHELL}
 }
 
 EOF
@@ -134,18 +134,18 @@ install_pkg() {
             exit 1
         fi
 
-        case ${ADJUSTED_ID} in
+        case "${ADJUSTED_ID}" in
         debian)
-            ${PKG_MGR_CMD} update && ${INSTALL_CMD} "${pkg_name}"
+            "${PKG_MGR_CMD}" update && "${INSTALL_CMD}" "${pkg_name}"
             ;;
         rhel)
-            ${PKG_MGR_CMD} update && ${INSTALL_CMD} "${pkg_name}"
+            "${PKG_MGR_CMD}" update && "${INSTALL_CMD}" "${pkg_name}"
             ;;
         alpine)
-            ${PKG_MGR_CMD} update && ${INSTALL_CMD} "${pkg_name}"
+            "${PKG_MGR_CMD}" update && "${INSTALL_CMD}" "${pkg_name}"
             ;;
         arch)
-            ${INSTALL_CMD} "${pkg_name}"
+            "${INSTALL_CMD}" "${pkg_name}"
             ;;
         *)
             print_err "Error: Unable to install ${pkg_name} for distro ${ID}"
@@ -158,7 +158,7 @@ install_pkg() {
 # Description: Update shell configuration files
 update_rc() {
     _rc=""
-    case ${ADJUSTED_ID} in
+    case "${ADJUSTED_ID}" in
     debian | rhel)
         _rc="${HOME}/.bashrc"
         ;;
@@ -200,7 +200,7 @@ update_rc() {
 
 OS=$(uname)
 
-case ${OS} in
+case "${OS}" in
 Linux)
     # Bring in ID, ID_LIKE, VERSION_ID, VERSION_CODENAME
     # shellcheck source=/dev/null


### PR DESCRIPTION
This pull request makes several improvements to the `install.sh` script by consistently quoting variable expansions, which helps prevent word splitting and globbing issues in shell scripts. This enhances the script's safety and reliability across different environments.

Shell script safety and quoting improvements:

* Consistently added double quotes around variable expansions such as `${UPDATE_SCRIPT_SOURCE_URL}`, `${ADJUSTED_ID}`, `${PKG_MGR_CMD}`, and `${INSTALL_CMD}` in command invocations and case statements to prevent word splitting and globbing. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL54-R54) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL137-R148) [[3]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL161-R161) [[4]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL203-R203)