### PR TITLE
Fix Update mindepth if not cleaned up

### DIFF
--- a/.update.sh
+++ b/.update.sh
@@ -142,7 +142,7 @@ update_snapd() {
 update_os_pkg() {
     case "${ADJUSTED_ID}" in
     debian)
-        if [ "$(find /var/lib/apt/lists/* -maxdepth 1 -type f 2>/dev/null | wc -l)" -eq 0 ]; then
+        if [ "$(find /var/lib/apt/lists/ -maxdepth 1 -type f 2>/dev/null | wc -l)" -eq 0 ]; then
             println "Updating ${PKG_MGR_CMD} based packages..."
             if ! ("${PKG_MGR_CMD}" update -y &&
                 "${PKG_MGR_CMD}" upgrade -y &&


### PR DESCRIPTION
This pull request makes a minor adjustment to the logic for detecting whether the APT package lists are empty on Debian systems. The change simplifies the `find` command used in the `update_os_pkg()` function to avoid unnecessary directory traversal.

- Simplified the `find` command in the Debian case of `update_os_pkg()` by removing the `-mindepth 1` argument, ensuring it correctly counts files at the top level of `/var/lib/apt/lists/`.