### PR TITLE
Debian: apt update not working

### DIFF
--- a/.update.sh
+++ b/.update.sh
@@ -142,7 +142,7 @@ update_snapd() {
 update_os_pkg() {
     case "${ADJUSTED_ID}" in
     debian)
-        if [ "$(find /var/lib/apt/lists/ -maxdepth 1 -type f 2>/dev/null | wc -l)" -eq 0 ]; then
+        if [ "$(find /var/lib/apt/lists/* -maxdepth 1 -type f 2>/dev/null | wc -l)" -eq 0 ]; then
             println "Updating ${PKG_MGR_CMD} based packages..."
             if ! ("${PKG_MGR_CMD}" update -y &&
                 "${PKG_MGR_CMD}" upgrade -y &&


### PR DESCRIPTION
This pull request makes a minor fix to the logic that checks for the presence of apt package lists on Debian-based systems in the `.update.sh` script.

* Corrected the `find` command in the `update_os_pkg()` function to use `/var/lib/apt/lists/*` instead of `/var/lib/apt/lists/`, ensuring it accurately counts files when checking if the apt package lists are present.